### PR TITLE
fix python module use as external language interface throw exception

### DIFF
--- a/gadgetron/external/connection.py
+++ b/gadgetron/external/connection.py
@@ -178,7 +178,7 @@ class Connection:
         message_identifier = self._read_message_identifier()
         assert(message_identifier == constants.GADGET_MESSAGE_CONFIG)
         config_bytes = read_byte_string(self.socket)
-        return xml.fromstring(config_bytes), config_bytes
+        return None if config_bytes.strip()==b'<?xml version="1.0"?>' else xml.fromstring(config_bytes), config_bytes
 
     def _read_header(self):
         message_identifier = self._read_message_identifier()


### PR DESCRIPTION
improve compitable

config info is not a must need part, the read_config assume it will always be a valid xml document, which is not in fact? it will crash.

@dchansen Hi, I am not sure whether this is the right way to do this, on my machine it's always not right and config content is b'<?xml version="1.0"?>' which cause   the follow code throw exception.

```python
return xml.fromstring(config_bytes), config_bytes # the xml is  xml.etree.ElementTree type and the config_bytes is <?xml version="1.0"?>'
```

step to reproduce error:

run gadgetron:
```bash
gadgetron_ismrmrd_client -f testdata.h5  -c 'my_python.xml'
```

my_python.xml
```xml 
<configuration>
<version>2</version>
<readers>
    <reader>
        <classname>AcquisitionReader</classname>
        <dll>gadgetron_core_readers</dll>
    </reader>
</readers>

<stream>
    <external>
        <connect port="18000" />
    </external>
</stream>

<writers>
<writer>
    <classname>ImageWriter</classname>
    <dll>gadgetron_core_writers</dll>
</writer>
</writers>

```

visualization program
```bash
python3 /home/cz/projects/GadgetronOnlineClass/Courses/Day1/Lecture2/visualization/visualization.py
```
error result
```bash
/usr/bin/python3.9 /home/cz/projects/GadgetronOnlineClass/Courses/Day1/Lecture2/visualization/visualization.py
[INFO] Accepted connection from client: ('::1', 45762, 0, 0)
Traceback (most recent call last):
  File "/home/cz/projects/GadgetronOnlineClass/Courses/Day1/Lecture2/visualization/visualization.py", line 135, in <module>
    gadgetron.external.listen(18000, spawn_process)
  File "/home/cz/.local/lib/python3.9/site-packages/gadgetron/external/listen.py", line 33, in listen
    with connection.Connection(wait_for_client_connection(port)) as conn:
  File "/home/cz/.local/lib/python3.9/site-packages/gadgetron/external/connection.py", line 54, in __init__
    self.config, self.raw_bytes.config = self._read_config()
  File "/home/cz/.local/lib/python3.9/site-packages/gadgetron/external/connection.py", line 182, in _read_config
    return xml.fromstring(config_bytes), config_bytes
  File "/usr/lib/python3.9/xml/etree/ElementTree.py", line 1348, in XML
    return parser.close()
xml.etree.ElementTree.ParseError: no element found: line 2, column 0
```

